### PR TITLE
feat: add Snacks picker backend and config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The plugin should help you to learn some basic (:wq, write and quit) and some no
 I have provided a solid initial batch of tips and if you have your favorite one that is not listed, I will be happy to include it in the next release **with proper credits**. Send your commands, tips and tricks to me, create an issue or submit a pull request. You can also add your own tips and tricks that will be stored on your local computer, you don't have to share anything with me.  
 
 ## ✨ Features
-- Search tips using ultra-fast `fzf-lua` plugin
+- Search tips using fzf-lua or Snacks picker
 - Preview rendered descriptions in markdown format
 - No additional utilities: you don't need `glow` or `bat` to render the tip
 - Support for categories, tags, and rich text
@@ -60,6 +60,25 @@ I have provided a solid initial batch of tips and if you have your favorite one 
   end
 }
 ```
+
+#### Using Snacks picker
+
+If you prefer the Snacks picker, add folke/snacks.nvim and set picker = 'snacks':
+
+```lua
+{
+  "saxon1964/neovim-tips",
+  dependencies = {
+    "folke/snacks.nvim",
+  },
+  opts = {
+    picker = "snacks",
+    user_file = vim.fn.stdpath("config") .. "/neovim_tips/user_tips.md",
+  },
+}
+```
+
+Note: Ensure Snacks' picker is enabled in your Snacks setup (opts = { picker = { enabled = true } }).
 
 ### packer.nvim
 
@@ -251,7 +270,7 @@ This format is used for all tips, built-in or created by you and stored separate
 
 Each tip has to start with the `# Title:` line, followed by `# Category:` and a list of `# Tags`.
 
-Description of the tip starts with `---` and ends with `===`. There is **NO** predefined format for description. Anything between the starting and ending marker will be interpreted as a text in markdown (.md) format. Fzf-lua will render the markdown description in the right FZF panel. 
+Description of the tip starts with `---` and ends with `===`. There is **NO** predefined format for description. Anything between the starting and ending marker will be interpreted as a text in markdown (.md) format. Your configured picker will render the markdown description in its preview panel.
 
 ## ✅ Example
 
@@ -294,6 +313,9 @@ require("neovim_tips").setup({
   
   -- Show warnings when user tips have conflicting titles with builtin tips
   warn_on_conflicts = true,
+  
+    -- Picker backend: 'fzf-lua' (default) or 'snacks'
+    picker = 'fzf-lua',
 })
 ```
 

--- a/lua/neovim_tips/config.lua
+++ b/lua/neovim_tips/config.lua
@@ -4,6 +4,7 @@ M.options = {
   user_file = vim.fn.stdpath("config") .. "/neovim_tips/user_tips.md",
   user_tip_prefix = "[User] ",  -- Configurable prefix for user tips
   warn_on_conflicts = true,     -- Show warnings when user tips conflict with builtin
+  picker = "fzf-lua",           -- Picker to use: "fzf-lua" (default) or "snacks"
   -- for internal use only
   builtin_dir = debug.getinfo(1, "S").source:sub(2):gsub("config.lua", "../../data"),
   user_tips_tag = "user",

--- a/lua/neovim_tips/init.lua
+++ b/lua/neovim_tips/init.lua
@@ -2,7 +2,6 @@ local M = {}
 
 local config = require("neovim_tips.config")
 local loader = require("neovim_tips.loader")
-local fzf_lua_picker = require("neovim_tips.fzf_lua")
 local utils = require("neovim_tips.utils")
 
 function M.setup(opts)
@@ -22,7 +21,12 @@ function M.setup(opts)
             if result then
               vim.notify("Neovim tips loaded", vim.log.levels.INFO)
             end
-            fzf_lua_picker.show_fzf()
+            local picker = (config.options.picker or "fzf-lua"):lower()
+            if picker == "snacks" then
+              require("neovim_tips.snacks").show()
+            else
+              require("neovim_tips.fzf_lua").show_fzf()
+            end
           else
             vim.notify("Failed to load Neovim tips: " .. result, vim.log.levels.ERROR)
           end

--- a/lua/neovim_tips/snacks.lua
+++ b/lua/neovim_tips/snacks.lua
@@ -1,0 +1,52 @@
+local M = {}
+
+-- Snacks-based picker for Neovim Tips
+-- This integrates with folke/snacks.nvim's picker API
+
+local tips = require("neovim_tips.tips")
+
+function M.show()
+  -- Lazily require Snacks and validate that the picker module is available
+  local ok, Snacks = pcall(require, "snacks")
+  if not ok or not Snacks or not Snacks.picker then
+    vim.notify(
+      "Snacks picker not available. Please install 'folke/snacks.nvim' and enable its picker.",
+      vim.log.levels.ERROR
+    )
+    return
+  end
+
+  local titles = tips.get_titles()
+  if not titles or #titles == 0 then
+    vim.notify("No tips available", vim.log.levels.INFO)
+    return
+  end
+
+  -- Build items with inline markdown preview using Snacks' built-in previewer
+  local items = {}
+  for i, title in ipairs(titles) do
+    local content = tips.get_description(title) or ""
+    items[i] = {
+      text = title,
+      preview = {
+        text = content,
+        ft = "markdown", -- render as markdown
+        loc = false,      -- do not show location info
+      },
+    }
+  end
+
+  -- Launch Snacks picker with our items
+  Snacks.picker.pick({
+    items = items,
+    format = "text",
+    preview = "preview",
+    prompt = "Search Tips> ",
+    title = "Neovim Tips",
+    confirm = "close", -- close picker on confirm
+    focus = "input",
+  })
+end
+
+return M
+


### PR DESCRIPTION
Provide an optional Snacks-based picker to make the tip search UI pluggable and lighter for users who prefer snacks.nvim. Introduces a `picker` setup option (defaults to `fzf-lua`) and runtime dispatch in :NeovimTips to select the backend. Adds a small adapter module for Snacks with inline markdown preview and updates the README with installation/configuration examples.