### PR TITLE
Add configurable markdown renderer (render-markdown or markview)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ I have provided a solid initial batch of tips and if you have your favorite one 
 ## ✨ Features
 - **Beautiful custom picker**: Three-pane interface with search, tips list, and live markdown preview
 - **Daily tip popup**: Get a random tip on startup (configurable: off, daily, or every launch)
-- **Lightweight dependencies**: Only requires `nui.nvim` and `render-markdown` - no heavyweight pickers (fzf-lua, telescope, snacks, mini...)
+- **Lightweight dependencies**: Only requires `nui.nvim` and a markdown renderer — `render-markdown.nvim` (default) or `markview.nvim` — no heavyweight pickers (fzf-lua, telescope, snacks, mini...)
 - **Word-based search**: Intelligent search that matches all words (e.g., "insert character" finds "character to insert")
 - **Live markdown rendering**: Preview rendered descriptions with full markdown support
 - **Simple navigation**: Seamless mouse and keyboard navigation with smart mode switching
@@ -38,6 +38,10 @@ I have provided a solid initial batch of tips and if you have your favorite one 
 - Automatic title conflict detection and warnings
 
 ## 📦 Installation
+
+Renderer dependency:
+- Default: MeanderingProgrammer/render-markdown.nvim
+- Alternative: OXY2DEV/markview.nvim (set `renderer = "markview"` in setup). Refer to markview's README for Tree-sitter requirements and loading order notes.
 
 ### Lazy.nvim
 
@@ -258,7 +262,7 @@ The plugin can show you a random tip in a beautiful popup when you start Neovim.
 ### Daily Tip Popup Features:
 - **"Did you know?" popup**: Centered popup with random tip
 - **Smart persistence**: Once daily mode uses `~/.local/share/nvim/neovim_tips/persistent.json` 
-- **Full markdown rendering**: Rich formatting with render-markdown.nvim
+- **Full markdown rendering**: Rich formatting via the configured renderer
 - **Easy dismissal**: Close with `q` or `<Esc>`
 - **Error reporting**: Includes GitHub issues link for feedback
 
@@ -338,6 +342,8 @@ require("neovim_tips").setup({
   
   -- Daily tip mode: 0=off, 1=once per day, 2=every startup
   daily_tip = 1,
+  -- Renderer to use for markdown preview: "render-markdown" (default) or "markview"
+  renderer = "render-markdown",
 })
 ```
 

--- a/lua/neovim_tips/config.lua
+++ b/lua/neovim_tips/config.lua
@@ -7,6 +7,7 @@ local M = {}
 ---@field user_tip_prefix string Prefix for user tips to avoid conflicts
 ---@field warn_on_conflicts boolean Show warnings when user tips conflict with builtin tips
 ---@field daily_tip integer Daily tip mode: 0=off, 1=once per day, 2=every startup
+---@field renderer string Renderer to use: "render-markdown" | "markview"
 ---@field builtin_dir string Internal: path to builtin tips data directory
 ---@field user_tips_tag string Internal: tag for user tips identification
 ---@field github_url string URL to the project repository
@@ -17,6 +18,7 @@ M.options = {
   user_tip_prefix = "[User] ",  -- Configurable prefix for user tips
   warn_on_conflicts = true,     -- Show warnings when user tips conflict with builtin
   daily_tip = 1,                -- Daily tip mode: 0=off, 1=once per day, 2=every startup
+  renderer = "render-markdown", -- Renderer: "render-markdown" (default) or "markview"
   -- for internal use only
   builtin_dir = debug.getinfo(1, "S").source:sub(2):gsub("config.lua", "../../data"),
   user_tips_tag = "user",

--- a/lua/neovim_tips/daily_tip.lua
+++ b/lua/neovim_tips/daily_tip.lua
@@ -167,11 +167,20 @@ local function show_daily_tip(update_last_shown)
   vim.bo[popup.bufnr].modifiable = false
   vim.bo[popup.bufnr].readonly = true
 
-  -- Enable markdown rendering if available
-  if pcall(require, "render-markdown") then
-    vim.api.nvim_buf_call(popup.bufnr, function()
-      require("render-markdown").enable()
-    end)
+  -- Enable markdown rendering based on configured renderer
+  local renderer = config.options.renderer
+  if renderer == "markview" then
+    if pcall(require, "markview") then
+      vim.api.nvim_buf_call(popup.bufnr, function()
+        vim.cmd("Markview enable")
+      end)
+    end
+  else
+    if pcall(require, "render-markdown") then
+      vim.api.nvim_buf_call(popup.bufnr, function()
+        require("render-markdown").enable()
+      end)
+    end
   end
 
   -- Set up keymaps to close

--- a/lua/neovim_tips/render.lua
+++ b/lua/neovim_tips/render.lua
@@ -1,0 +1,56 @@
+--- Centralized rendering logic for markdown preview
+--- Chooses the configured renderer and renders the given buffer
+local M = {}
+
+local config = require("neovim_tips.config")
+
+-- Run a function with the buffer set and, if available, inside a window that displays it.
+-- Some renderers (like Markview) are window-sensitive and behave more reliably in a window context.
+local function with_buffer_context(bufnr, fn)
+  local winid = vim.fn.bufwinid(bufnr)
+  if winid ~= -1 and vim.api.nvim_win_is_valid(winid) then
+    vim.api.nvim_win_call(winid, function()
+      if vim.api.nvim_get_current_buf() ~= bufnr then
+        vim.api.nvim_set_current_buf(bufnr)
+      end
+      fn()
+    end)
+  else
+    vim.api.nvim_buf_call(bufnr, fn)
+  end
+end
+
+-- Open all folds and disable folding in the current window
+local function open_folds()
+  pcall(vim.cmd, "silent! normal! zR")
+  vim.wo.foldlevel = 99
+  vim.wo.foldenable = false
+  vim.wo.foldmethod = "manual"
+end
+
+---Render markdown in a buffer according to configured renderer
+---@param bufnr integer|nil Buffer number to render (defaults to current buffer)
+function M.render(bufnr)
+  bufnr = bufnr or vim.api.nvim_get_current_buf()
+  local renderer = config.options.renderer
+
+  if renderer == "markview" then
+    -- Use markview.nvim: force refresh by disabling and enabling via user commands
+    with_buffer_context(bufnr, function()
+      -- Disable then enable; wrap in pcall in case commands are unavailable
+      pcall(vim.cmd, "Markview disable")
+      pcall(vim.cmd, "Markview enable")
+      open_folds()
+    end)
+  else
+    -- Default: render-markdown.nvim via user commands (supports lazy-loading by cmd)
+    with_buffer_context(bufnr, function()
+      pcall(vim.cmd, "RenderMarkdown disable")
+      pcall(vim.cmd, "RenderMarkdown enable")
+      open_folds()
+    end)
+  end
+end
+
+return M
+


### PR DESCRIPTION
- Add options.renderer with default "render-markdown" and support for "markview" in config.lua
- Use selected renderer in daily tip and picker previews, enabling render-markdown or Markview based on configuration
- Adjust picker preview buffer buftype for markview (avoid "nofile") to allow attachment
- Update README to document renderer selection and requirements

This change lets users choose their preferred markdown rendering backend without altering the default behavior.