### PR TITLE
Clarify that xclip can only be run on X11

### DIFF
--- a/data/clipboard.md
+++ b/data/clipboard.md
@@ -408,7 +408,7 @@ vim.api.nvim_create_autocmd('BufWritePost', {
 # Category: clipboard
 # Tags: linux, clipboard, external-tool
 ---
-Easily copy and paste between Vim and system clipboard using xclip, which is particularly useful for handling large amounts of text
+On X11, easily copy and paste between Vim and system clipboard using xclip, which is particularly useful for handling large amounts of text
 
 ```vim
 " Mapping to copy entire buffer to clipboard

--- a/data/editing.md
+++ b/data/editing.md
@@ -1417,7 +1417,7 @@ vim.opt.joinspaces = false
 # Category: editing
 # Tags: clipboard, cursor-preservation
 ---
-Use a mark to maintain cursor position when pasting from clipboard
+Use a mark to maintain cursor position when pasting from clipboard using xclip on X11.
 
 ```vim
 map <F7> mz:-1r !xclip -o -sel clip<CR>`z


### PR DESCRIPTION
There are two tips that reference running `xclip`. The command `xclip` only works on systems that run X11. It doesn't work on Wayland, or on Windows or macOS for that matter. This pull request adds that clarification.